### PR TITLE
Bug: stats::lm() produces NA-containing ty.

### DIFF
--- a/R/bcajack2.R
+++ b/R/bcajack2.R
@@ -90,7 +90,6 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 1
     qbca2 <- function(Y, tt, t0, alpha, pct) {
         m <- ncol(Y)
         B <- nrow(Y)
-        o1 <- rep(1, m)
         D <- rep(0, B)
 
         for (i in seq_len(B)) {

--- a/R/bcajack2.R
+++ b/R/bcajack2.R
@@ -104,7 +104,7 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2,
         Qd <- stats::quantile(D, pct)
         ip <- seq_len(B)[D <= Qd]
         stopifnot("length(ip) < ncol(Y) makes lm() produce NA-containing ty." =
-                  (length(ip)<ncol(Y)))
+                  (length(ip) >= ncol(Y)))
         ty. <- as.vector(m * stats::lm(tt[ip] ~ Y[ip, ] - 1)$coef)
         ty. <- ty. - mean(ty.)
         a <- (1/6) * sum(ty.^3)/sum(ty.^2)^1.5

--- a/R/bcajack2.R
+++ b/R/bcajack2.R
@@ -76,8 +76,8 @@
 #' bcajack2(x = Xy, B = 1000, func = rfun, m = 40, verbose = FALSE)
 #'
 #' @export
-bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 12,
-                     alpha = c(0.025, 0.05, 0.1, 0.16),
+bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2,
+                     J = 12, alpha = c(0.025, 0.05, 0.1, 0.16),
                      verbose = TRUE) {
 
     call <- match.call()
@@ -86,6 +86,9 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 1
     if (!exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE))
         stats::runif(1)
     seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+
+    stopifnot("tt & t0 must contain no missing values" =
+                  (!is.na(tt) & !is.na(t0)))
 
     qbca2 <- function(Y, tt, t0, alpha, pct) {
         m <- ncol(Y)

--- a/R/bcajack2.R
+++ b/R/bcajack2.R
@@ -103,6 +103,8 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2,
         }
         Qd <- stats::quantile(D, pct)
         ip <- seq_len(B)[D <= Qd]
+        stopifnot("length(ip) < ncol(Y) makes lm() produce NA-containing ty." =
+                  (length(ip)<ncol(Y)))
         ty. <- as.vector(m * stats::lm(tt[ip] ~ Y[ip, ] - 1)$coef)
         ty. <- ty. - mean(ty.)
         a <- (1/6) * sum(ty.^3)/sum(ty.^2)^1.5

--- a/R/bcajack2.R
+++ b/R/bcajack2.R
@@ -103,15 +103,12 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 1
         ty. <- as.vector(m * stats::lm(tt[ip] ~ Y[ip, ] - 1)$coef)
         ty. <- ty. - mean(ty., na.rm = TRUE)
         a <- (1/6) * sum(ty.^3, na.rm = TRUE)/sum(ty.^2, na.rm = TRUE)^1.5
-        ## if (sw == 3)
-        ##     return(ty.)
         s <- mean(tt)
         B.mean <- c(B, s)
 
         zalpha <- stats::qnorm(alpha)
         nal <- length(alpha)
         ustat <- 2 * t0 - s
-        ##s. <- m * .v(stats::cov(tt, Y))
         s. <- m * as.vector(stats::cov(tt, Y))
         u. <- 2 * ty. - s.
         sdu <- sum(u.^2)^0.5/m
@@ -127,7 +124,6 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 1
         ooo <- pmin(pmax(ooo, 1), B)
         lims <- sort(tt)[ooo]
         standard <- t0 + sdboot * stats::qnorm(alpha)
-        ##lims <- round(cbind(lims, standard), rou)
         lims <- cbind(lims, standard)
         dimnames(lims) <- list(alpha, c("bca", "std"))
         stats <- c(t0, sdboot, z0, a, sdjack)
@@ -144,7 +140,6 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 1
         tt <- B$tt
         t0 <- B$t0
         B <- length(tt)
-        ##vl0 <- qbca2(Y, tt, t0, alpha = alpha, pct = pct, rou = rou)
         vl0 <- qbca2(Y, tt, t0, alpha = alpha, pct = pct)
     } else {
         if (is.vector(x))
@@ -165,7 +160,6 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 1
                 if (verbose) utils::setTxtProgressBar(pb, k)
             }
             if (verbose) close(pb)
-            ##vl0 <- qbca2(Y, tt, t0, alpha = alpha, pct = pct, rou = rou)
             vl0 <- qbca2(Y, tt, t0, alpha = alpha, pct = pct)
         }
 
@@ -186,7 +180,6 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 1
                 if (verbose) utils::setTxtProgressBar(pb, k)
             }
             if (verbose) close(pb)
-            ##vl0 <- qbca2(Y, tt, t0, alpha = alpha, pct = pct, rou = rou)
             vl0 <- qbca2(Y, tt, t0, alpha = alpha, pct = pct)
         }
     }
@@ -198,7 +191,6 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 1
 
     nal <- length(alpha)
     Pct <- rep(0, nal)
-    ##for (i in 1:nal) Pct[i] <- round(sum(tt <= vl0$lims[i, 1])/B, rou)
     for (i in 1:nal) Pct[i] <- sum(tt <= vl0$lims[i, 1])/B
     Stand <- vl0$stats[1] + vl0$stats[2] * stats::qnorm(alpha)
     Limsd <- matrix(0, length(alpha), K)
@@ -217,38 +209,25 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 1
             iij <- c(II[, -j])
             Yj <- Y[iij, ]
             ttj <- tt[iij]
-            ##vlj <- qbca2(Yj, ttj, t0, alpha, pct, rou)
             vlj <- qbca2(Yj, ttj, t0, alpha, pct)
             limbc[, j] <- vlj$lims[, 1]
             limst[, j] <- vlj$lims[, 2]
             stats[, j] <- vlj$stats
         }
 
-        ## if (sw == 4)
-        ##     return(list(limbc = limbc, limst = limst, stats = stats))
         Limbcsd[, k] <- apply(limbc, 1, sd) * (J - 1)/sqrt(J)
         Statsd[, k] <- apply(stats, 1, sd) * (J - 1)/sqrt(J)
-        ## if (verbose)
-        ##     cat("{", k, "}", sep = "")
-        ## if (sw == 6)
-        ##     return(list(Limbcsd = Limbcsd, Statsd = Statsd))
     }
     limsd <- rowMeans(Limbcsd, 1)
     statsd <- rowMeans(Statsd, 1)
-    ##limits <- round(cbind(vl0$lims[, 1], limsd, vl0$lims[, 2], Pct), rou)
     limits <- cbind(vl0$lims[, 1], limsd, vl0$lims[, 2], Pct)
     dimnames(limits) <- list(alpha, c("bca", "jacksd", "std", "pct"))
-    ##stats <- round(rbind(vl0$stats, statsd), rou)
     stats <- rbind(vl0$stats, statsd)
-    ##ustats <- round(vl0$ustats, rou)
     ustats <- vl0$ustats
-    ##B.mean <- c(B, round(mean(tt), rou))
     B.mean <- c(B, mean(tt))
     dimnames(stats) <- list(c("est", "jsd"), c("theta", "sdboot", "z0", "a", "sdjack"))
     vll <- list(call = call, lims = limits, stats = stats, B.mean = B.mean, ustats = ustats,
                 seed = seed)
-    ## if (sw == 5)
-    ##     vll$tt <- tt
     bcaboot.return(vll)
 }
 

--- a/R/bcajack2.R
+++ b/R/bcajack2.R
@@ -101,8 +101,8 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 1
         Qd <- stats::quantile(D, pct)
         ip <- seq_len(B)[D <= Qd]
         ty. <- as.vector(m * stats::lm(tt[ip] ~ Y[ip, ] - 1)$coef)
-        ty. <- ty. - mean(ty.)
-        a <- (1/6) * sum(ty.^3)/sum(ty.^2)^1.5
+        ty. <- ty. - mean(ty., na.rm = TRUE)
+        a <- (1/6) * sum(ty.^3, na.rm = TRUE)/sum(ty.^2, na.rm = TRUE)^1.5
         ## if (sw == 3)
         ##     return(ty.)
         s <- mean(tt)

--- a/R/bcajack2.R
+++ b/R/bcajack2.R
@@ -104,8 +104,8 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2,
         Qd <- stats::quantile(D, pct)
         ip <- seq_len(B)[D <= Qd]
         ty. <- as.vector(m * stats::lm(tt[ip] ~ Y[ip, ] - 1)$coef)
-        ty. <- ty. - mean(ty., na.rm = TRUE)
-        a <- (1/6) * sum(ty.^3, na.rm = TRUE)/sum(ty.^2, na.rm = TRUE)^1.5
+        ty. <- ty. - mean(ty.)
+        a <- (1/6) * sum(ty.^3)/sum(ty.^2)^1.5
         s <- mean(tt)
         B.mean <- c(B, s)
         names(B.mean) <- c("B", "s")

--- a/R/bcajack2.R
+++ b/R/bcajack2.R
@@ -87,10 +87,10 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2,
         stats::runif(1)
     seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
 
-    stopifnot("tt & t0 must contain no missing values" =
-                  (!is.na(tt) & !is.na(t0)))
-
     qbca2 <- function(Y, tt, t0, alpha, pct) {
+        stopifnot("tt & t0 must contain no missing values" =
+                      (!is.na(tt) & !is.na(t0)))
+
         m <- ncol(Y)
         B <- nrow(Y)
         D <- rep(0, B)
@@ -140,6 +140,9 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2,
     alpha <- c(alpha, 0.5, rev(1 - alpha))
 
     if (is.list(B)) {
+        stopifnot("To use the Blist format described in bcajack2() help,
+                  please name `B` as Y, tt & t0" =
+                      (names(B) == c("Y", "tt", "t0")))
         Y <- B$Y
         tt <- B$tt
         t0 <- B$t0

--- a/R/bcajack2.R
+++ b/R/bcajack2.R
@@ -105,6 +105,7 @@ bcajack2 <- function(x, B, func, ..., m = nrow(x), mr, pct = 0.333, K = 2, J = 1
         a <- (1/6) * sum(ty.^3, na.rm = TRUE)/sum(ty.^2, na.rm = TRUE)^1.5
         s <- mean(tt)
         B.mean <- c(B, s)
+        names(B.mean) <- c("B", "s")
 
         zalpha <- stats::qnorm(alpha)
         nal <- length(alpha)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,8 @@
 authors:
   Bradley Efron:
     href: https://efron.web.stanford.edu
+  Timothy M Pollington:
+    href: https://orcid.org/0000-0002-9688-5960
   Balasubramanian Narasimhan:
     href: https://statistics.stanford.edu/people/balasubramanian-narasimhan
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,7 +1,7 @@
 authors:
   Bradley Efron:
     href: https://efron.web.stanford.edu
-  Timothy M Pollington:
+  Timothy M Pollington: # bcajack2() bug correction
     href: https://orcid.org/0000-0002-9688-5960
   Balasubramanian Narasimhan:
     href: https://statistics.stanford.edu/people/balasubramanian-narasimhan

--- a/bcaboot.Rproj
+++ b/bcaboot.Rproj
@@ -5,7 +5,12 @@ SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
 Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes

--- a/deletemeifPRaccepted.justanexample.R
+++ b/deletemeifPRaccepted.justanexample.R
@@ -1,0 +1,16 @@
+data(diabetes, package = "bcaboot")
+Xy <- cbind(diabetes$x, diabetes$y)
+rfun <- function(Xy) {
+  y <- Xy[, 11]
+  X <- Xy[, 1:10]
+  summary(lm(y~X) )$adj.r.squared
+}
+set.seed(1234)
+inds = matrix(NA, nrow = 1000, ncol = nrow(Xy))
+inds = t(apply(inds, MARGIN = 1, function(inds) sample(1:nrow(Xy), replace = TRUE))) # get bootstrap indices to feed into estimator rfun()
+tt = vector(mode = "numeric", length = 1000)
+tt = apply(inds, MARGIN = 1, function(inds) rfun(Xy[inds,])) # get \hat{theta}*
+Y = t(apply(inds, MARGIN = 1, tabulate, nbins = nrow(Xy)))
+t0 = rfun(Xy)
+bcaboot::bcajack2(B = list(Y=Y, tt=tt, t0=t0), alpha = c(0.025,0.975),
+                  pct = 0.33)$lims[,1] # this produces NA BCa CIs, because a is NA, because B*pct=1000*0.33=330<442=n.


### PR DESCRIPTION
Following Issue #4 this is a minimal bug correction to prevent a user running bcajack2() if their `Y` choice leads to `B` * `pct` approximately being less than or equal to `n` aka `ncol(Y)`. 

Otherwise `lm()` will produce some `NA` entries in `ty.` as there are insufficient observations (`length(ip)`) to solve the matrix equation in `lm()`, considering the number of dimensions of `x` in `lm()` is `p` aka `ncol(Y)`. Happy to explain further, as I'm aware my explanation is spread across this PR and Issue #4.